### PR TITLE
Tab numbering improvements and Edge support

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,5 +30,4 @@ Now with self destructing tab numbers!  Enable the _Self Destruct_ option from t
 ### 📝 Notes ###
 * Tab numbers cannot be shown on Chrome tabs such as the New Tab Page or Settings
 * Tabs are only numbered up to 8 as there are only shortcuts for the first 8 tabs
-* Navigating away from the current page will cause the number to be removed from the tab title
-* Some websites update the tab title to show status updates which may remove the tab number
+* Websites that show status updates in the tab title may overwrite the tab number

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tumber",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,11 +1,12 @@
 {
   "name": "tumber",
-  "version": "1.1.0",
-  "description": "Show tab numbers in Google Chrome for tab jumping ninja!",
+  "version": "1.2.0",
+  "description": "Show tab numbers in Chromium browsers for tab jumping ninja!",
   "main": "src/index.js",
   "scripts": {
     "build": "webpack --env.development",
-    "build:prod": "webpack --env.production",
+    "build:chrome": "webpack --env.production --env.platform=chrome",
+    "build:edge": "webpack --env.production --env.platform=edge",
     "lint": "eslint src",
     "lint:fix": "eslint --fix src"
   },

--- a/src/constants.js
+++ b/src/constants.js
@@ -36,5 +36,5 @@ export const PARENT_MENU_CONTEXT = {
 };
 
 export const TAB_LIMIT = 8;
-
 export const SELF_DESTRUCT_TIME_MS = 4000;
+export const STATUS_COMPLETE = 'complete';

--- a/src/handlers.js
+++ b/src/handlers.js
@@ -16,8 +16,19 @@ import {
 
 export const isWindowActive = async (windowId) => {
   const { activeWindows } = await getLocalStorage();
-
   return activeWindows ? activeWindows.includes(windowId) : false;
+};
+
+const setTabTitle = ({ id, index, title }) => {
+  chrome.tabs.executeScript(id, {
+    code: `document.title = "${index + 1}: ${title.substring(
+      title.indexOf(':') + 1
+    )}";`,
+  });
+};
+
+export const showTabNumberInTab = (tab) => {
+  tab.url.includes('http') && setTabTitle(tab);
 };
 
 const showTabNumbersInAllWindows = () => {
@@ -47,13 +58,7 @@ const removeTabNumbersInAllWindows = async () => {
 export const showTabNumbersInWindow = (windowId) => {
   chrome.tabs.query({ windowId }, async (tabs) => {
     for (const tab of tabs) {
-      tab.url.includes('http') &&
-        tab.index < TAB_LIMIT &&
-        chrome.tabs.executeScript(tab.id, {
-          code: `document.title = "${tab.index + 1}: ${tab.title.substring(
-            tab.title.indexOf(':') + 1
-          )}";`,
-        });
+      tab.index < TAB_LIMIT && tab.url.includes('http') && setTabTitle(tab);
     }
 
     const { isSelfDestructEnabled } = await getLocalStorage();

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,8 @@ import {
   TOGGLE_ALL_CONTEXT,
   SETTINGS_SEPARATOR_CONTEXT,
   TOGGLE_SELF_DESTRUCT_CONTEXT,
+  TAB_LIMIT,
+  STATUS_COMPLETE,
 } from './constants';
 import {
   onClickHandler,
@@ -11,11 +13,22 @@ import {
   showTabNumbersInWindow,
   resetTabTitle,
   isWindowActive,
+  showTabNumberInTab,
 } from './handlers';
 import { removeActiveWindow } from './storage';
 
 chrome.commands.onCommand.addListener((command) => {
   onClickHandler(command);
+});
+
+chrome.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
+  if (
+    tab.index < TAB_LIMIT &&
+    changeInfo.status === STATUS_COMPLETE &&
+    (await isWindowActive(tab.windowId))
+  ) {
+    showTabNumberInTab(tab);
+  }
 });
 
 chrome.tabs.onMoved.addListener(async (tabId, moveInfo) => {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,9 +1,9 @@
 {
   "manifest_version": 2,
-  "name": "Tumber - Tab Numbers for Google Chrome\u2122",
+  "name": "",
   "short_name": "Tumber",
-  "description": "Show tab numbers in Google Chrome\u2122 for tab jumping ninja!",
-  "version": "1.1.0",
+  "description": "",
+  "version": "",
   "permissions": [
       "storage", "tabs", "contextMenus", "<all_urls>"
   ],

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,13 +1,61 @@
 const path = require('path');
 const CopyPlugin = require('copy-webpack-plugin');
 const { CleanWebpackPlugin } = require('clean-webpack-plugin');
+const metadata = require('./package.json');
+
+const CHROME = {
+  name: 'Tumber - Tab Numbers for Google Chrome\u2122',
+  description: 'Show tab numbers in Google Chrome\u2122 for tab jumping ninja!',
+};
+const EDGE = {
+  name: 'Tumber - Tab Numbers for Microsoft Edge\u2122',
+  description:
+    'Show tab numbers in Microsoft Edge\u2122 for tab jumping ninja!',
+};
+
+const optimize = (buffer, name, description) => {
+  const manifest = JSON.parse(buffer.toString());
+  manifest.version = metadata.version;
+  manifest.name = name;
+  manifest.description = description;
+  return JSON.stringify(manifest, null, 2);
+};
+
+const copyPluginConfig = (platform) => {
+  switch (platform) {
+    case 'chrome':
+      return {
+        patterns: [
+          { from: 'src/icons', to: 'icons' },
+          {
+            from: path.resolve(__dirname, 'src/manifest.json'),
+            transform(content) {
+              return optimize(content, CHROME.name, CHROME.description);
+            },
+          },
+        ],
+      };
+    case 'edge':
+      return {
+        patterns: [
+          { from: 'src/icons', to: 'icons' },
+          {
+            from: path.resolve(__dirname, 'src/manifest.json'),
+            transform(content) {
+              return optimize(content, EDGE.name, EDGE.description);
+            },
+          },
+        ],
+      };
+  }
+};
 
 module.exports = (env) => ({
   mode: env.production ? 'production' : 'development',
   devtool: env.production ? 'none' : 'inline-source-map',
   entry: './src/index.js',
   output: {
-    path: path.resolve(__dirname, 'dist'),
+    path: path.resolve(__dirname, `dist/${env.platform}`),
     filename: '[name].js',
   },
   resolve: {
@@ -15,10 +63,16 @@ module.exports = (env) => ({
   },
   plugins: [
     new CleanWebpackPlugin(),
+    new CopyPlugin(copyPluginConfig(env.platform)),
     new CopyPlugin({
       patterns: [
         { from: 'src/icons', to: 'icons' },
-        { from: path.resolve(__dirname, 'src/manifest.json') },
+        {
+          from: path.resolve(__dirname, 'src/manifest.json'),
+          transform(content) {
+            return optimize(content);
+          },
+        },
       ],
     }),
   ],

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,51 +3,48 @@ const CopyPlugin = require('copy-webpack-plugin');
 const { CleanWebpackPlugin } = require('clean-webpack-plugin');
 const metadata = require('./package.json');
 
-const CHROME = {
-  name: 'Tumber - Tab Numbers for Google Chrome\u2122',
-  description: 'Show tab numbers in Google Chrome\u2122 for tab jumping ninja!',
-};
-const EDGE = {
-  name: 'Tumber - Tab Numbers for Microsoft Edge\u2122',
-  description:
-    'Show tab numbers in Microsoft Edge\u2122 for tab jumping ninja!',
+const BROWSERS = {
+  chrome: {
+    name: 'Tumber - Tab Numbers for Google Chrome\u2122',
+    description:
+      'Show tab numbers in Google Chrome\u2122 for tab jumping ninja!',
+  },
+  edge: {
+    name: 'Tumber - Tab Numbers for Microsoft Edge\u2122',
+    description:
+      'Show tab numbers in Microsoft Edge\u2122 for tab jumping ninja!',
+  },
 };
 
-const optimize = (buffer, name, description) => {
-  const manifest = JSON.parse(buffer.toString());
-  manifest.version = metadata.version;
-  manifest.name = name;
-  manifest.description = description;
+const optimize = (buffer, platform) => {
+  const template = JSON.parse(buffer.toString());
+
+  const manifest = {
+    ...template,
+    version: metadata.version,
+    name: platform ? BROWSERS[platform].name : metadata.name,
+    description: platform
+      ? BROWSERS[platform].description
+      : metadata.description,
+  };
+
   return JSON.stringify(manifest, null, 2);
 };
 
-const copyPluginConfig = (platform) => {
-  switch (platform) {
-    case 'chrome':
-      return {
-        patterns: [
-          { from: 'src/icons', to: 'icons' },
-          {
-            from: path.resolve(__dirname, 'src/manifest.json'),
-            transform(content) {
-              return optimize(content, CHROME.name, CHROME.description);
-            },
-          },
-        ],
-      };
-    case 'edge':
-      return {
-        patterns: [
-          { from: 'src/icons', to: 'icons' },
-          {
-            from: path.resolve(__dirname, 'src/manifest.json'),
-            transform(content) {
-              return optimize(content, EDGE.name, EDGE.description);
-            },
-          },
-        ],
-      };
-  }
+const copyPluginConfig = (env) => {
+  return {
+    patterns: [
+      { from: 'src/icons', to: 'icons' },
+      {
+        from: path.resolve(__dirname, 'src/manifest.json'),
+        transform(content) {
+          return env.development
+            ? optimize(content)
+            : optimize(content, env.platform);
+        },
+      },
+    ],
+  };
 };
 
 module.exports = (env) => ({
@@ -55,27 +52,13 @@ module.exports = (env) => ({
   devtool: env.production ? 'none' : 'inline-source-map',
   entry: './src/index.js',
   output: {
-    path: path.resolve(__dirname, `dist/${env.platform}`),
+    path: path.resolve(__dirname, 'dist'),
     filename: '[name].js',
   },
   resolve: {
     extensions: ['*', '.js'],
   },
-  plugins: [
-    new CleanWebpackPlugin(),
-    new CopyPlugin(copyPluginConfig(env.platform)),
-    new CopyPlugin({
-      patterns: [
-        { from: 'src/icons', to: 'icons' },
-        {
-          from: path.resolve(__dirname, 'src/manifest.json'),
-          transform(content) {
-            return optimize(content);
-          },
-        },
-      ],
-    }),
-  ],
+  plugins: [new CleanWebpackPlugin(), new CopyPlugin(copyPluginConfig(env))],
   module: {
     rules: [
       {


### PR DESCRIPTION
* Persist tab numbers even when page is changed
* Create separate build config for Chrome and Edge
* Dynamically set version number in manifest.json from package.json
* Fixes #17